### PR TITLE
Update puppetlabs-concat version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">=1.2.3 <2.0.0"
+      "version_requirement": ">=1.2.3 <=4.0.1"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I could not see any reason why puppetlabs-concat had to be <2.0.0 and this requirement causes issues when using with combination with other modules that require newer version. 